### PR TITLE
Fixed: EXC_BAD_ACCESS when saving scanned documents because of an ext…

### DIFF
--- a/ios/Classes/SwiftFlutterIOSDocScannerPlugin.swift
+++ b/ios/Classes/SwiftFlutterIOSDocScannerPlugin.swift
@@ -56,7 +56,6 @@ public class SwiftFlutterIOSDocScanner: NSObject, FlutterPlugin {
             DispatchQueue.main.async {
                 result(imagePaths)
             }
-            result(imagePaths)
         }
     }
 }


### PR DESCRIPTION
Fixed: EXC_BAD_ACCESS when saving scanned documents because of an extra call to the result closure after having already called it on the main dispatch queue